### PR TITLE
feat(spike_sorting): handle cases when no units/spikes are found

### DIFF
--- a/element_array_ephys/spike_sorting/si_spike_sorting.py
+++ b/element_array_ephys/spike_sorting/si_spike_sorting.py
@@ -412,11 +412,17 @@ class PostProcessing(dj.Imported):
 
         analyzer_output_dir = output_dir / sorter_name / "sorting_analyzer"
 
+        has_units = si_sorting.unit_ids.size > 0
+
         @memoized_result(
             uniqueness_dict=postprocessing_params,
             output_directory=analyzer_output_dir,
         )
         def _sorting_analyzer_compute():
+            if not has_units:
+                log.info("No units found in sorting object. Skipping sorting analyzer.")
+                return
+
             # Sorting Analyzer
             sorting_analyzer = si.create_sorting_analyzer(
                 sorting=si_sorting,
@@ -440,6 +446,8 @@ class PostProcessing(dj.Imported):
 
         _sorting_analyzer_compute()
 
+        do_si_export = postprocessing_params.get("export_to_phy", False) or postprocessing_params.get("export_report", False)
+
         self.insert1(
             {
                 **key,
@@ -448,8 +456,7 @@ class PostProcessing(dj.Imported):
                     datetime.utcnow() - execution_time
                 ).total_seconds()
                 / 3600,
-                "do_si_export": postprocessing_params.get("export_to_phy", False)
-                or postprocessing_params.get("export_report", False),
+                "do_si_export": do_si_export and has_units,
             }
         )
 


### PR DESCRIPTION
Minor updates to the pipeline to skip additional processing steps if there is no units found from spike sorting