### PR TITLE
Copy `recording.dat` if available instead of regenerating with `write_binary_recording()`

### DIFF
--- a/element_array_ephys/spike_sorting/si_spike_sorting.py
+++ b/element_array_ephys/spike_sorting/si_spike_sorting.py
@@ -554,12 +554,11 @@ class SIExport(dj.Computed):
             )
 
             if existing_rec_dat:
-                # Copy recording.dat
                 dest_fp = analyzer_output_dir / "phy" / "recording.dat"
                 log.info(f"Copy recording.dat to {dest_fp} for phy export.")
                 if not(dest_fp.exists() and dest_fp.stat().st_size == src_fp.stat().st_size):
                     shutil.copy(src_fp, dest_fp)
-                # Update `dat_path` in params.py
+                log.info("Update `dat_path` in `params.py`.")
                 params_py = analyzer_output_dir / "phy" / "params.py"
                 with params_py.open("r") as f:
                     params_content = [l for l in f.readlines() if not l.startswith("dat_path = ")]

--- a/element_array_ephys/spike_sorting/si_spike_sorting.py
+++ b/element_array_ephys/spike_sorting/si_spike_sorting.py
@@ -3,7 +3,7 @@ The following DataJoint pipeline implements the sequence of steps in the spike-s
 """
 
 from datetime import datetime
-
+import shutil
 import datajoint as dj
 import pandas as pd
 import spikeinterface as si
@@ -534,14 +534,34 @@ class SIExport(dj.Computed):
             output_directory=analyzer_output_dir / "phy",
         )
         def _export_to_phy():
+            # copy the recording.dat
+            rec_dat_query = SIClustering.File & key & "file_name LIKE '%recording.dat'"
+            if rec_dat_query:
+                src_fp = rec_dat_query.fetch("file", limit=1)[0]
+                dest_fp = analyzer_output_dir / "phy" / "recording.dat"
+                shutil.copy(src_fp, dest_fp)
+                existing_rec_dat = True
+                log.info(f"Recording.dat copied to {dest_fp} for phy export. ")
+            else:
+                existing_rec_dat = False
+
             # Save to phy format
             si.exporters.export_to_phy(
                 sorting_analyzer=sorting_analyzer,
                 output_folder=analyzer_output_dir / "phy",
                 use_relative_path=True,
                 remove_if_exists=True,
+                copy_binary=not existing_rec_dat,
                 **job_kwargs,
             )
+
+            # Update `dat_path` in params.py
+            params_py = analyzer_output_dir / "phy" / "params.py"
+            with params_py.open("r") as f:
+                params_content = [l for l in f.readlines() if not l.startswith("dat_path = ")]
+            params_content.insert(0, "dat_path = r'recording.dat'\n")
+            with params_py.open("w") as f:
+                f.writelines(params_content)
 
         @memoized_result(
             uniqueness_dict=postprocessing_params,


### PR DESCRIPTION
This pull request introduces enhancements to the spike sorting pipeline in the `element_array_ephys` package, specifically in the `si_spike_sorting.py` file. The changes improve handling of `recording.dat` files during the export to Phy format, ensuring compatibility and robustness in the workflow.

### Enhancements to `recording.dat` handling:

* **New logic to handle existing `recording.dat` files**: Added a query to check for the presence of an existing `recording.dat` file in the database. If found, it is copied to the appropriate location for Phy export. Otherwise, the binary file is generated during the export process. (`[element_array_ephys/spike_sorting/si_spike_sorting.pyR537-R568](diffhunk://#diff-8b09d8ffff860fa9ea85406b982afafede135c65eac1bdcc9067d3d18745aaf3R537-R568)`)
* **Update to `params.py` for `dat_path`**: Modified the `params.py` file in the Phy output directory to include the correct `dat_path` pointing to the `recording.dat` file. This ensures that Phy can locate the file. (`[element_array_ephys/spike_sorting/si_spike_sorting.pyR537-R568](diffhunk://#diff-8b09d8ffff860fa9ea85406b982afafede135c65eac1bdcc9067d3d18745aaf3R537-R568)`)
