### PR TITLE
Update to align with spikeinterface API changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
  [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [0.4.2] - 2025-12-11
+
++ Fix - Update `export_to_phy()` and `export_report()` to use `folder` parameter instead of deprecated `output_folder` for spikeinterface API compatibility
+
 ## [0.4.1] - 2025-03-18
 
 + Fix - Add key_source to `ProbeLevelReport` to filter for 'good' quality units

--- a/element_array_ephys/spike_sorting/si_spike_sorting.py
+++ b/element_array_ephys/spike_sorting/si_spike_sorting.py
@@ -546,7 +546,7 @@ class SIExport(dj.Computed):
             # Save to phy format
             si.exporters.export_to_phy(
                 sorting_analyzer=sorting_analyzer,
-                output_folder=analyzer_output_dir / "phy",
+                folder=analyzer_output_dir / "phy",
                 use_relative_path=True,
                 remove_if_exists=True,
                 copy_binary=not existing_rec_dat,
@@ -574,7 +574,7 @@ class SIExport(dj.Computed):
             # Generate spike interface report
             si.exporters.export_report(
                 sorting_analyzer=sorting_analyzer,
-                output_folder=analyzer_output_dir / "spikeinterface_report",
+                folder=analyzer_output_dir / "spikeinterface_report",
                 remove_if_exists=True,
                 **job_kwargs,
             )

--- a/element_array_ephys/version.py
+++ b/element_array_ephys/version.py
@@ -1,3 +1,3 @@
 """Package metadata."""
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"


### PR DESCRIPTION
This pull request updates the usage of the SpikeInterface exporters in `si_spike_sorting.py` to align with recent changes in their API. The main change is renaming the `output_folder` argument to `folder` in calls to exporter functions.

**SpikeInterface exporter API updates:**

* Updated the argument name from `output_folder` to `folder` in the call to `si.exporters.export_to_phy` within the `_export_to_phy` function to match the updated SpikeInterface API.
* Updated the argument name from `output_folder` to `folder` in the call to `si.exporters.export_report` within the `_export_report` function to match the updated SpikeInterface API.