### PR TITLE
Add 'no kilosort label' to ClusterQualityLabel contents

### DIFF
--- a/element_array_ephys/ephys.py
+++ b/element_array_ephys/ephys.py
@@ -756,6 +756,11 @@ class ClusterQualityLabel(dj.Lookup):
         ("mua", "multi-unit activity"),
         ("noise", "bad unit"),
         ("n.a.", "not available"),
+        (
+            "no kilosort label",
+            "No kilosort label exists for this unit, likely because it was"
+            " the result of a merge or split during manual curation.",
+        ),
     ]
 
 


### PR DESCRIPTION
## Summary

The `ClusterQualityLabel` lookup table's `contents` list was missing the "no kilosort label" entry that already exists in the production database. This label is assigned to units created by merge or split during manual curation.

When a read-only database user (e.g., the `coscientist` service account) imports this schema, DataJoint detects the mismatch between `contents` (5 rows) and the database (6 rows) and attempts a `skip_duplicates=True` INSERT. That INSERT fails with a permission error, blocking schema activation for any user without write access to the ephys schema.

Adding the sixth label to `contents` brings the code in sync with the database and eliminates the spurious INSERT attempt.