### PR TITLE
Add 'no kilosort label' to ClusterQualityLabel contents (spikeinterface branch)

### DIFF
--- a/element_array_ephys/ephys_no_curation.py
+++ b/element_array_ephys/ephys_no_curation.py
@@ -767,6 +767,11 @@ class ClusterQualityLabel(dj.Lookup):
         ("mua", "multi-unit activity"),
         ("noise", "bad unit"),
         ("n.a.", "not available"),
+        (
+            "no kilosort label",
+            "No kilosort label exists for this unit, likely because it was"
+            " the result of a merge or split during manual curation.",
+        ),
     ]
 
 


### PR DESCRIPTION
## Summary

Same fix as #22, applied to `ephys_no_curation.py` on the `datajoint-spikeinterface` branch (which is what the Shuler pipeline actually depends on).

The `ClusterQualityLabel` lookup's `contents` was missing the "no kilosort label" entry that exists in the production database, causing a `skip_duplicates=True` INSERT on schema activation that fails for read-only users like the `coscientist` service account.